### PR TITLE
blink every 30 seconds, for even more battery lifetime

### DIFF
--- a/blink.ino
+++ b/blink.ino
@@ -18,7 +18,7 @@ void setup() {
 // the loop routine runs over and over again forever:
 void loop() {
   digitalWrite(led, HIGH);   // turn the LED on (HIGH is the voltage level)
-  delay(30000);               // wait for thirty seconds
+  delay(30000);               // wait for thirty seconds: #! CHANGES MADE
   digitalWrite(led, LOW);    // turn the LED off by making the voltage LOW
   delay(500);               // blink for half a second
 }

--- a/blink.ino
+++ b/blink.ino
@@ -18,7 +18,7 @@ void setup() {
 // the loop routine runs over and over again forever:
 void loop() {
   digitalWrite(led, HIGH);   // turn the LED on (HIGH is the voltage level)
-  delay(10000);               // wait for ten seconds
+  delay(30000);               // wait for thirty seconds
   digitalWrite(led, LOW);    // turn the LED off by making the voltage LOW
   delay(500);               // blink for half a second
 }


### PR DESCRIPTION
This will expand even further the battery lifetime at the cost of having to wait 30 seconds when checking if the sensors are working properly.